### PR TITLE
Modify linkedin count URL

### DIFF
--- a/lib/social_counter.rb
+++ b/lib/social_counter.rb
@@ -67,7 +67,7 @@ class SocialCounter
   end
 
   def linkedin_count
-    request_url = "http://www.linkedin.com/countserv/count/share?url=#{@url}&format=json"
+    request_url = "https://www.linkedin.com/countserv/count/share?url=#{@url}&format=json"
     JSON.parser.new(open(request_url).read).parse["count"].to_i
   end
 


### PR DESCRIPTION
Linkedin's URL was changed to the https URL.
